### PR TITLE
Add support for Latin

### DIFF
--- a/treetagger.py
+++ b/treetagger.py
@@ -17,7 +17,7 @@ from sys import platform as _platform
 
 _treetagger_url = 'http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/'
 
-_treetagger_languages = ['bulgarian', 'dutch', 'english', 'estonian', 'finnish', 'french', 'galician', 'german', 'italian', 'polish', 'russian', 'slovak', 'slovak2', 'spanish']
+_treetagger_languages = ['bulgarian', 'dutch', 'english', 'estonian', 'finnish', 'french', 'galician', 'german', 'italian', 'latin', 'polish', 'russian', 'slovak', 'slovak2', 'spanish']
 
 class TreeTagger(TaggerI):
     r"""


### PR DESCRIPTION
Add 'latin' to ```_treetagger_languages```. Tested with the Latin parameter file installed.